### PR TITLE
fix failing compile on android

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -129,7 +129,7 @@ impl Compiler {
                 source.len(),
                 self.options.get(),
                 &raw mut len,
-            );
+            ) as *const i8; // explicit conversion needed to compile on android
 
             CompilerResult { bytecode, len }
         }


### PR DESCRIPTION
rs-luau was failing to compile due to weird platform specific behavior on android (rust bug?) that typed the return of `luau_compile` as `*mut u8` instead of the `*const i8` needed by the `CompilerResult` struct. Added an explicit `as const* i8` conversion that seems to have fixed it. 